### PR TITLE
add {get,get_mut}_or_default accessors for World

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -49,18 +49,6 @@ impl World {
             .and_then(|i| Ok(AtomicRefMut::map(i, |j| j.downcast_mut::<T>().unwrap())))
     }
 
-    /// Get an immutable reference to a resource by type, default-initializing it if not already
-    /// initialized.
-    ///
-    /// Will return an error if the type is:
-    /// - Already borrowed mutably
-    pub fn get_or_default<T: Default + Send + Sync + 'static>(
-        &mut self,
-    ) -> Result<AtomicRef<T>, EcsError> {
-        self.initialize::<T>();
-        self.get()
-    }
-
     /// Get a mutable reference to a resource by type, default-initializing it if not already
     /// initialized.
     ///

--- a/src/world.rs
+++ b/src/world.rs
@@ -51,15 +51,9 @@ impl World {
 
     /// Get a mutable reference to a resource by type, default-initializing it if not already
     /// initialized.
-    ///
-    /// Will return an error if the type is:
-    /// - Already borrowed immutably
-    /// - Already borrowed mutably
-    pub fn get_mut_or_default<T: Default + Send + Sync + 'static>(
-        &mut self,
-    ) -> Result<AtomicRefMut<T>, EcsError> {
+    pub fn get_mut_or_default<T: Default + Send + Sync + 'static>(&mut self) -> AtomicRefMut<T> {
         self.initialize::<T>();
-        self.get_mut()
+        self.get_mut().unwrap()
     }
 
     /// Get a mutable reference to a resource by its type id. Useful if using

--- a/src/world.rs
+++ b/src/world.rs
@@ -104,4 +104,12 @@ mod tests {
         }
         assert_eq!(*world.get_mut::<u32>().unwrap(), 6);
     }
+
+    #[test]
+    fn init_or_default() {
+        let mut world = World::default();
+
+        let mut data = world.get_mut_or_default::<u32>();
+        *data += 1;
+    }
 }


### PR DESCRIPTION
This adds an alternative "non-failing" API for retrieving resources. It's unfortunately a bit limited (for `get_mut_or_default` specifically) since the `&mut self` prevents overlapping borrows. Haven't found any good ways of holding the resources for multiple entities without adding a lock, but the below works well enough for non-performance constrained code.

The way I've used it is like so:

```rust
fn spawn_something(world: &mut World) {
    let entity = world
        .get_mut_or_default::<Entities>()
        .expect("cannot fail in sequential code")
        .create();

    world
        .get_mut_or_default::<Components<MyComponent>>()
        .expect("cannot fail in sequential code")
        .insert(entity, MyComponent {});
}
```

I find this style convenient for preloading the world, as I can parametrize the creation in any way I want.

Unfortunately rustfmt had opinions here; I'll fix it manually if you like.